### PR TITLE
Specify which zip folder to download in the release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can download a version in the [releases page](https://github.com/Synthird/Fi
 
 ### Opening the exe in the zip folder (Windows only)
 
-1. Download and unzip the zip folder
+1. Download and unzip the zip folder called "File-reader.zip"
 3. Open the exe file
 4. If you get a pop-up saying the exe might be a virus
     - Click "More info"


### PR DESCRIPTION
There are two zip folders in each release page. Specify the zip folder that users needed to download.