### PR TITLE
Lowercased the zip file name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can download a version in the [releases page](https://github.com/Synthird/Fi
 
 ### Opening the exe in the zip folder (Windows only)
 
-1. Download and unzip the zip folder called ```File-reader.zip```
+1. Download and unzip the zip folder called ```file-reader.zip```
 2. Open the exe file in the unzipped folder
 3. If you get a pop-up saying the exe might be a virus, just run it anyway
 


### PR DESCRIPTION
The first letter in the name of the zip file has been lowercased in version 1.4.3.